### PR TITLE
fix for content-security-policy connection refused

### DIFF
--- a/app/filters/AppSecurityHeadersFilter.scala
+++ b/app/filters/AppSecurityHeadersFilter.scala
@@ -1,8 +1,0 @@
-package filters
-
-import javax.inject.Inject
-
-import play.api.http.DefaultHttpFilters
-import play.filters.headers.SecurityHeadersFilter
-
-class AppSecurityHeadersFilter @Inject() (securityHeadersFilter: SecurityHeadersFilter) extends DefaultHttpFilters(securityHeadersFilter)

--- a/app/filters/AppSecurityHeadersFilter.scala
+++ b/app/filters/AppSecurityHeadersFilter.scala
@@ -1,0 +1,8 @@
+package filters
+
+import javax.inject.Inject
+
+import play.api.http.DefaultHttpFilters
+import play.filters.headers.SecurityHeadersFilter
+
+class AppSecurityHeadersFilter @Inject() (securityHeadersFilter: SecurityHeadersFilter) extends DefaultHttpFilters(securityHeadersFilter)

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ scalaVersion := "2.12.2"
 
 libraryDependencies += guice
 libraryDependencies += ws
+libraryDependencies += filters
 
 libraryDependencies += "org.webjars" % "flot" % "0.8.3"
 libraryDependencies += "org.webjars" % "bootstrap" % "3.3.6"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -10,8 +10,7 @@
 #  }
 #}
 
-play.http.filters = "filters.AppSecurityHeadersFilter"
-play.filters.headers.contentSecurityPolicy = "connect-src 'self' ws://localhost:9000/ws"
+play.filters.headers.contentSecurityPolicy="default-src 'self'; connect-src 'self' ws://localhost:9000"
 
 default.stocks = ["GOOG", "AAPL", "ORCL"]
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -10,6 +10,9 @@
 #  }
 #}
 
+play.http.filters = "filters.AppSecurityHeadersFilter"
+play.filters.headers.contentSecurityPolicy = "connect-src 'self' ws://localhost:9000/ws"
+
 default.stocks = ["GOOG", "AAPL", "ORCL"]
 
 sentiment.url = "http://text-processing.com/api/sentiment/"

--- a/test/actors/StocksActorSpec.scala
+++ b/test/actors/StocksActorSpec.scala
@@ -25,6 +25,33 @@ class StocksActorSpec extends TestKitSpec {
       val stockHistory = probe.receiveOne(500 millis)
       stockHistory mustBe a[StockHistory]
     }
+    
+    "send a unwatchStock message to the user" in {
+      val probe = new TestProbe(system)
+      val probeStock = new TestProbe(system)
 
+      val stocksActor = system.actorOf(Props[StocksActor])
+
+      // create an actor which will test the UserActor
+      val userActor = system.actorOf(Props(new ProbeWrapper(probe)))
+
+      // First watch stock
+      stocksActor.tell(WatchStock(symbol), userActor)
+
+      // the userActor will be added as a watcher and get a message with the stock history
+      val userActorMessage = probe.receiveOne(500 millis)
+      userActorMessage mustBe a[StockHistory]
+
+      // the userActor will get a message with the stock update
+      val stockUpdateMsg = probe.receiveOne(500 millis)
+      stockUpdateMsg mustBe a[StockUpdate]
+
+      // now unwatch 
+      stocksActor.tell(UnwatchStock(Some(symbol)), userActor)
+
+      // Should not expect any more messages at this point
+      probe.expectNoMsg()
+    }
+    
   }
 }


### PR DESCRIPTION
Just forked latest from branch 2.6.x and without doing any modifications when running with sbt run getting connection error while creating web sockets. Browser is rejecting the WebSocket connection due to missing content-policy-security header.

ERROR MSG in browser console:
Content Security Policy: The page's settings blocked the loading of a resource at ws://localhost:9000/ws A content security policy header should be explicitly sent back from the server in order for the browser allow that connection to be open.

My changes include the following:

new Security headers filters and application.conf updates (fixes issue above)