### PR TITLE
Clean stock streams

### DIFF
--- a/app/actors/UserActor.scala
+++ b/app/actors/UserActor.scala
@@ -107,8 +107,8 @@ class UserActor @Inject()(@Assisted id: String, @Named("stocksActor") stocksActo
   private def addStock(stock: Stock): Unit = {
     // We convert everything to JsValue so we get a single stream for the websocket.
     // Make sure the history gets written out before the updates for this stock...
-    val historySource = stock.history(50).map(s => Json.toJson(StockHistory(stock.symbol, s.map(_.price))))
-    val updateSource = stock.update.map(sq => Json.toJson(StockUpdate(sq.symbol, sq.price)))
+    val historySource = stock.history(50).map(sh => Json.toJson(sh))
+    val updateSource = stock.update.map(su => Json.toJson(su))
     val stockSource = historySource.concat(updateSource)
 
     // Set up a flow that will let us pull out a killswitch for this specific stock,

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -64,10 +64,7 @@ class HomeController @Inject()(@Named("userParentActor") userParentActor: ActorR
     implicit val timeout = Timeout(1.second) // the first run in dev can take a while :-(
     val future: Future[Any] = userParentActor ? UserParentActor.Create(request.id.toString)
     val futureFlow: Future[Flow[JsValue, JsValue, NotUsed]] = future.mapTo[Flow[JsValue, JsValue, NotUsed]]
-    futureFlow.map { flow =>
-      // Fail the websocket stream if we are backed up by more than a second.
-      flow.backpressureTimeout(10.seconds)
-    }
+    futureFlow
   }
 
 }


### PR DESCRIPTION
* Use grouped instead of Sink.seq
* Use `StockHistory` and `StockUpdate` source
* Remove backpressureTimeout from flow (not needed)